### PR TITLE
Remove faulty restore state code

### DIFF
--- a/custom_components/sensorpush/__init__.py
+++ b/custom_components/sensorpush/__init__.py
@@ -195,24 +195,9 @@ class SensorPushEntity(RestoreEntity):
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
-        
+
         # register callback when cached SensorPush data has been updated
         async_dispatcher_connect(self.hass, SIGNAL_SENSORPUSH_UPDATED, self._update_callback)
-
-        # on restart, attempt to restore previous state (see https://aarongodfrey.dev/programming/restoring-an-entity-in-home-assistant/)
-        state = await self.async_get_last_state()
-        if not state:
-            return
-        self._state = state.state
-
-        # restore any attributes (FIXME: why not restore ALL attributes?)
-        for attribute in [ATTR_AGE, ATTR_OBSERVED_TIME, ATTR_BATTERY_VOLTAGE, ATTR_ALERT_MIN, ATTR_ALERT_MAX]:
-            if attribute in state.attributes:
-                value = state.attributes.get(attribute)
-                if value:
-                    self._attrs[attribute] = value
-
-        LOG.debug(f"Restored sensor {self._name} previous state {self._state}: {self._attrs}")
 
         async_dispatcher_connect(
             self.hass, DATA_UPDATED, self._schedule_immediate_update


### PR DESCRIPTION
On restart, all of the sensors report an erroneous value (-5 or thereabouts), which causes chaos with automation and makes graphs ugly.

This is because the restore state code does not work properly. It overrides `async_added_to_hass` with code specifically designed to restore attributes after a restart ([see this post](https://aarongodfrey.dev/programming/restoring-an-entity-in-home-assistant/)), which seems to be of dubious value given the only attribute added is the battery voltage, which probably ought to be its own sensor anyway. Plus, it's all filled in on the next update anyway, whereas the original integration this was designed for relies on some internal logic to change the attribute, which wasn't firing on init (though firing that on init would have been a viable solution too)

In any case, the simple fix for _this_ integration was to just not restore state, which results in an unknown (or null, I guess) state on a restart, which is then filled in on the next update from the sensors. This is how must integrations work, won't cause chaos with integrations, and won't pollute our precious graphs.